### PR TITLE
chore: use fixed version for pycarol

### DIFF
--- a/batch-carolapp-docker/Dockerfile
+++ b/batch-carolapp-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM totvslabs/pycarol
+FROM totvslabs/pycarol:2.33.1
 
 RUN mkdir /app
 WORKDIR /app

--- a/batch-carolapp-docker/app/task_failed.py
+++ b/batch-carolapp-docker/app/task_failed.py
@@ -8,19 +8,16 @@ from pycarol.apps import Apps
 from pycarol.tasks import Tasks
 
 class docker_environ_vars():
-
+    
     def __init__(self):
-        self.caroldomain = ''
         self.caroltenant = ''
         self.carolappoauth = ''
         self.carolconnectorir = ''
         self.longtaskid = ''
-
+    
     def docker_enviroment_variables_validation(self):
         fault_vars = []
 
-        if 'CAROLDOMAIN' not in os.environ:
-            fault_vars.append('CAROLDOMAIN')
         if 'CAROLTENANT' not in os.environ:
             fault_vars.append('CAROLTENANT')
         if 'CAROLAPPOAUTH' not in os.environ:
@@ -37,7 +34,6 @@ class docker_environ_vars():
 
     def load_vars(self):
         self.docker_enviroment_variables_validation()
-        self.caroldomain = os.environ['CAROLDOMAIN']
         self.caroltenant = os.environ['CAROLTENANT']
         self.carolappoauth = os.environ['CAROLAPPOAUTH']
         self.carolconnectorir = os.environ['CAROLCONNECTORID']
@@ -50,7 +46,7 @@ print("-------------------------------")
 env_vars = docker_environ_vars()
 env_vars.load_vars()
 
-carol = Carol(domain=env_vars.caroldomain,
+carol = Carol(domain=env_vars.caroltenant,
               app_name='',
               auth=ApiKeyAuth(env_vars.carolappoauth),
               connector_id=env_vars.carolconnectorir,

--- a/batch-carolapp-docker/app/task_failed.py
+++ b/batch-carolapp-docker/app/task_failed.py
@@ -8,16 +8,19 @@ from pycarol.apps import Apps
 from pycarol.tasks import Tasks
 
 class docker_environ_vars():
-    
+
     def __init__(self):
+        self.caroldomain = ''
         self.caroltenant = ''
         self.carolappoauth = ''
         self.carolconnectorir = ''
         self.longtaskid = ''
-    
+
     def docker_enviroment_variables_validation(self):
         fault_vars = []
 
+        if 'CAROLDOMAIN' not in os.environ:
+            fault_vars.append('CAROLDOMAIN')
         if 'CAROLTENANT' not in os.environ:
             fault_vars.append('CAROLTENANT')
         if 'CAROLAPPOAUTH' not in os.environ:
@@ -34,6 +37,7 @@ class docker_environ_vars():
 
     def load_vars(self):
         self.docker_enviroment_variables_validation()
+        self.caroldomain = os.environ['CAROLDOMAIN']
         self.caroltenant = os.environ['CAROLTENANT']
         self.carolappoauth = os.environ['CAROLAPPOAUTH']
         self.carolconnectorir = os.environ['CAROLCONNECTORID']
@@ -46,7 +50,7 @@ print("-------------------------------")
 env_vars = docker_environ_vars()
 env_vars.load_vars()
 
-carol = Carol(domain=env_vars.caroltenant,
+carol = Carol(domain=env_vars.caroldomain,
               app_name='',
               auth=ApiKeyAuth(env_vars.carolappoauth),
               connector_id=env_vars.carolconnectorir,

--- a/batch_carolapp/Dockerfile
+++ b/batch_carolapp/Dockerfile
@@ -1,4 +1,4 @@
-FROM totvslabs/pycarol:2.30.0
+FROM totvslabs/pycarol:2.33.1
 
 RUN mkdir /app
 WORKDIR /app

--- a/batch_carolapp/docker/ci_image/Dockerfile
+++ b/batch_carolapp/docker/ci_image/Dockerfile
@@ -1,5 +1,5 @@
 # https://github.com/buildkite/agent/blob/master/packaging/docker/ubuntu-linux/Dockerfile
-FROM totvslabs/pycarol:2.30.0
+FROM totvslabs/pycarol:2.33.1
 
 ENV LANG "en_US.UTF-8"
 ENV LANGUAGE "en_US.UTF-8"
@@ -16,5 +16,3 @@ RUN set -x &&\
     pip install -r requirements-dev.txt
 
 VOLUME [ "/src" ]
-
-

--- a/online-carol-app/Dockerfile
+++ b/online-carol-app/Dockerfile
@@ -1,4 +1,4 @@
-FROM totvslabs/pycarol:2.32.1
+FROM totvslabs/pycarol:2.33.1
 
 RUN mkdir /app
 WORKDIR /app


### PR DESCRIPTION
pyCarol removed the `:latest` tag, so those Dockerfiles are breaking now.
 