### PR TITLE
fix: include dash package to fix start online Carol app error

### DIFF
--- a/online-carol-app/requirements.txt
+++ b/online-carol-app/requirements.txt
@@ -1,3 +1,4 @@
+dash
 flask
 flask-login
 flask-wtf


### PR DESCRIPTION
Fix error below during Carol Online App start process:
`File "/app/app/__init__.py", line 1, in <module> import dash ModuleNotFoundError: No module named 'dash'`

Print screen:
![image](https://user-images.githubusercontent.com/3916127/119994777-4d286700-bfa3-11eb-927e-0a7abae2f15d.png)
